### PR TITLE
Implement bullet duplication via portal teleport

### DIFF
--- a/bullet.gd
+++ b/bullet.gd
@@ -5,7 +5,17 @@ var timer: int = 0
 var speed = 750
 var linear_velocity = 100
 func _physics_process(delta):
-	position += transform.x * speed * delta
+        position += transform.x * speed * delta
+
+func teleport(target_portal: Node2D) -> void:
+        # Move this bullet to the exit portal
+        global_position = target_portal.global_position
+
+        # Spawn an additional bullet with the same orientation
+        var bullet_scene = preload("res://Scenes/bullet.tscn")
+        var extra_bullet = bullet_scene.instantiate()
+        extra_bullet.global_transform = global_transform
+        get_parent().add_child(extra_bullet)
 
 func _on_Bullet_body_entered(body):
 	print("Bullet on_Bullet_body_entered")


### PR DESCRIPTION
## Summary
- add teleport handler to `bullet.gd`
- spawn an extra bullet when a bullet teleports through a portal

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860445d26248330acd99b0ed121efdb